### PR TITLE
Feature/granular auto responder presets

### DIFF
--- a/.claude/commands/disable-auto.md
+++ b/.claude/commands/disable-auto.md
@@ -1,0 +1,36 @@
+---
+description: Disable Claude auto-responder for current session
+allowedTools: ["Bash"]
+---
+
+I want to disable the Claude auto-responder for this tmux session.
+
+**Immediately run:**
+
+```bash
+# Get current session name
+CURRENT_SESSION=$(tmux display-message -p "#{session_name}")
+
+# Kill the auto-responder window
+tmux kill-window -t "$CURRENT_SESSION:Auto-Responder" 2>/dev/null || echo "Auto-responder was not running"
+
+# Show status
+echo "✅ Auto-responder disabled for session: $CURRENT_SESSION"
+```
+
+**Then explain:**
+1. Auto-responder has been stopped
+2. All future prompts will require manual approval
+3. How to re-enable if needed (/enable-auto)
+4. Current session is back to full manual control
+
+**Manual Control Restored:**
+- All file operations require confirmation
+- All commands require confirmation  
+- All git operations require confirmation
+- Maximum security, manual oversight
+
+**To re-enable:** Use `/enable-auto [preset]`
+
+# Usage:
+# /disable-auto

--- a/.claude/commands/enable-auto.md
+++ b/.claude/commands/enable-auto.md
@@ -1,0 +1,80 @@
+---
+description: Enable Claude auto-responder with preset configurations
+allowedTools: ["Bash"]
+---
+
+I want to enable the Claude auto-responder for this tmux session.
+
+**Arguments:** $ARGUMENTS
+
+Parse the arguments to identify the preset type:
+- If no arguments: Use pm_orchestrator preset (default)
+- If "pm": Use pm_orchestrator preset
+- If "safe" or "dev": Use safe_development preset
+- If "auto" or "autonomous": Use autonomous_agent preset
+- If "conservative": Use conservative preset
+
+**Immediately run the setup command:**
+
+```bash
+./enable_auto_responder.sh [preset_name]
+```
+
+**Preset Explanations:**
+
+🎯 **pm_orchestrator** (default for PMs):
+- ✅ File operations (documentation, reports)
+- ✅ General confirmations (workflow)
+- ✅ Continue operations (task flow)
+- ❌ Command execution (developers handle)
+- ❌ Git operations (oversight only)
+- ❌ Package management (technical team)
+- 🛡️ Risk: LOW-MEDIUM
+
+🔧 **safe_development** (for developers):
+- ✅ File operations (coding)
+- ✅ General confirmations
+- ✅ Continue operations
+- ❌ Command execution (manual control)
+- ❌ Git operations (manual control)
+- ❌ Package management (manual control)
+- 🛡️ Risk: LOW
+
+🚀 **autonomous_agent** (full automation):
+- ✅ File operations
+- ✅ Command execution
+- ✅ General confirmations
+- ✅ Package management
+- ❌ Git operations (safety)
+- ⚠️ Risk: MEDIUM
+
+🔒 **conservative** (minimal automation):
+- ✅ General confirmations only
+- ❌ Everything else manual
+- 🛡️ Risk: VERY LOW
+
+**After setup, explain:**
+1. What was enabled/disabled
+2. How this is safer than --dangerously-skip-permissions
+3. How to stop it (kill Auto-Responder window)
+4. How to check status
+
+**Key Benefits:**
+- Maintains Claude's permission system
+- Granular control vs all-or-nothing
+- Safety controls prevent dangerous operations
+- Complete audit trail
+- Can be stopped anytime
+
+# Usage Examples:
+# /enable-auto
+# /enable-auto pm
+# /enable-auto safe
+# /enable-auto autonomous
+# /enable-auto conservative
+
+# PM + Engineer Workflow Example:
+# PM: /enable-auto pm
+# PM: "You are a project manager, create an engineer in window 2 and say him:
+#      '/enable-auto conservative' and after say him create denofresh default
+#      project for now, schedule in 10 minutes to check engineer progress"

--- a/README.md
+++ b/README.md
@@ -252,11 +252,14 @@ For fully autonomous operation, the Claude Auto-Responder automatically handles 
 Before starting the auto-responder, ensure each Claude session in your tmux windows has **"auto-accept edits on"** enabled. This is crucial for the auto-responder to work properly with file modifications.
 
 ```bash
-# Start auto-responder for a session
+# Start auto-responder for a session (session name is required)
 python3 claude_auto_responder.py my-session
 
-# Or use the convenience script
+# Or use the convenience script (session name is required)
 ./start_auto_responder.sh my-session
+
+# With custom check interval
+./start_auto_responder.sh my-session 1.5
 ```
 
 **Features:**

--- a/README.md
+++ b/README.md
@@ -244,10 +244,40 @@ The orchestrator can share insights between projects:
 - "Authentication is working in Project A, use same pattern in Project B"
 - "Performance issue found in shared library, fix across all projects"
 
+## 🤖 Claude Auto-Responder
+
+For fully autonomous operation, the Claude Auto-Responder automatically handles confirmation prompts:
+
+**Prerequisites:**
+Before starting the auto-responder, ensure each Claude session in your tmux windows has **"auto-accept edits on"** enabled. This is crucial for the auto-responder to work properly with file modifications.
+
+```bash
+# Start auto-responder for a session
+python3 claude_auto_responder.py my-session
+
+# Or use the convenience script
+./start_auto_responder.sh my-session
+```
+
+**Features:**
+- Monitors all windows in a tmux session
+- Detects Claude confirmation prompts automatically
+- Responds with appropriate "yes" answers
+- Runs in background without interrupting workflow
+- Configurable check intervals
+
+**Use Cases:**
+- Long-running autonomous agents
+- Overnight development sessions
+- Unattended CI/CD operations
+- Batch processing workflows
+
 ## 📚 Core Files
 
 - `send-claude-message.sh` - Simplified agent communication script
 - `schedule_with_note.sh` - Self-scheduling functionality
+- `claude_auto_responder.py` - Automatic prompt response system
+- `start_auto_responder.sh` - Auto-responder launcher script
 - `tmux_utils.py` - Tmux interaction utilities
 - `CLAUDE.md` - Agent behavior instructions
 - `LEARNINGS.md` - Accumulated knowledge base

--- a/README.md
+++ b/README.md
@@ -275,6 +275,23 @@ python3 claude_auto_responder.py my-session
 - Unattended CI/CD operations
 - Batch processing workflows
 
+**Granular Presets:**
+- `pm_orchestrator`: PM-optimized (file ops, confirmations, no commands)
+- `safe_development`: Developer-safe (files, confirmations, manual commands)
+- `conservative`: Minimal automation (basic confirmations only)
+- `autonomous_agent`: Full automation (everything except git)
+
+**Example PM + Engineer Workflow:**
+```bash
+# PM enables auto-responder for management tasks
+/enable-auto pm
+
+# PM creates engineer and sets up conservative auto-responder
+# "You are a project manager, create an engineer in window 2 and say him:
+# '/enable-auto conservative' and after say him create denofresh default
+# project for now, schedule in 10 minutes to check engineer progress"
+```
+
 ## 📚 Core Files
 
 - `send-claude-message.sh` - Simplified agent communication script

--- a/claude_auto_responder.py
+++ b/claude_auto_responder.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Claude Auto-Responder for Tmux Sessions
+
+Automatically responds to Claude's confirmation prompts in tmux sessions.
+Monitors all windows in a session and responds with appropriate confirmations.
+"""
+
+import subprocess
+import time
+import re
+import sys
+from typing import List, Dict
+
+class ClaudeAutoResponder:
+    """Automatically responds to Claude confirmation prompts in tmux sessions."""
+
+    def __init__(self, session_name: str):
+        self.session_name = session_name
+        self.running = True
+
+        # Patterns that indicate Claude is asking for confirmation
+        self.question_patterns = [
+            r"1\.\s*yes\s*2\.\s*no",
+            r"1\.\s*yes\s*2\.\s*yes and don't ask again\s*3\.\s*no",
+            r"Confirm\?\s*\(yes/no\)",
+            r"Continue\?\s*\(y/n\)",
+            r"Proceed\?\s*\(yes/no\)",
+            r"Do you want to continue\?",
+            r"Do you want to proceed\?",
+            r"Apply these changes\?",
+            r"Execute this command\?"
+        ]
+    
+    def get_session_windows(self) -> List[int]:
+        """Get all windows in the tmux session."""
+        try:
+            cmd = ["tmux", "list-windows", "-t", self.session_name, "-F", "#{window_index}"]
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            return [int(w) for w in result.stdout.strip().split('\n') if w]
+        except subprocess.CalledProcessError:
+            return []
+
+    def capture_window_content(self, window_index: int, lines: int = 20) -> str:
+        """Capture content from a tmux window."""
+        try:
+            cmd = ["tmux", "capture-pane", "-t", f"{self.session_name}:{window_index}",
+                   "-p", "-S", f"-{lines}"]
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            return result.stdout
+        except subprocess.CalledProcessError:
+            return ""
+
+    def send_response(self, window_index: int, response: str = "1"):
+        """Send automatic response to a tmux window."""
+        try:
+            subprocess.run(["tmux", "send-keys", "-t", f"{self.session_name}:{window_index}", response])
+            time.sleep(0.5)
+            subprocess.run(["tmux", "send-keys", "-t", f"{self.session_name}:{window_index}", "Enter"])
+            print(f"✅ Auto-responded '{response}' to window {window_index}")
+            return True
+        except subprocess.CalledProcessError as e:
+            print(f"❌ Error sending response: {e}")
+            return False
+    
+    def check_for_questions(self, window_index: int) -> bool:
+        """Check if there are Claude questions in the window."""
+        content = self.capture_window_content(window_index)
+        if not content:
+            return False
+
+        for pattern in self.question_patterns:
+            if re.search(pattern, content, re.IGNORECASE | re.MULTILINE):
+                print(f"🔍 Question detected in window {window_index}")
+                print(f"Pattern: {pattern}")
+                print(f"Content: {content[-200:]}")
+                return True
+
+        return False
+
+    def watch_session(self, check_interval: float = 2.0):
+        """Monitor the entire tmux session continuously."""
+        print(f"🔍 Starting Claude Auto-Responder for session: {self.session_name}")
+        print(f"⏱️  Check interval: {check_interval} seconds")
+        print("🛑 Press Ctrl+C to stop")
+
+        try:
+            while self.running:
+                windows = self.get_session_windows()
+
+                for window_index in windows:
+                    if self.check_for_questions(window_index):
+                        content = self.capture_window_content(window_index)
+                        if "yes and don't ask again" in content.lower():
+                            self.send_response(window_index, "2")
+                        else:
+                            self.send_response(window_index, "1")
+
+                time.sleep(check_interval)
+
+        except KeyboardInterrupt:
+            print("\n🛑 Auto-responder stopped by user")
+        except Exception as e:
+            print(f"❌ Error in watcher: {e}")
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 claude_auto_responder.py <session_name> [check_interval]")
+        print("Example: python3 claude_auto_responder.py antko-corporate 1.5")
+        sys.exit(1)
+    
+    session_name = sys.argv[1]
+    check_interval = float(sys.argv[2]) if len(sys.argv) > 2 else 2.0
+    
+    responder = ClaudeAutoResponder(session_name)
+    responder.watch_session(check_interval)
+
+if __name__ == "__main__":
+    main()

--- a/enable_auto_responder.sh
+++ b/enable_auto_responder.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+#
+# Enable Auto-Responder for Current Tmux Session
+# 
+# This script automatically sets up the Claude auto-responder for the current
+# tmux session using predefined permission presets.
+#
+# Usage: ./enable_auto_responder.sh [preset_name]
+# Example: ./enable_auto_responder.sh pm_orchestrator
+#
+
+set -e  # Exit on any error
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRESET_NAME=${1:-"pm_orchestrator"}
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}🚀 Claude Auto-Responder Setup${NC}"
+echo "=================================="
+
+# Get current tmux session info
+if [ -z "$TMUX" ]; then
+    echo -e "${RED}❌ Error: Not running inside a tmux session${NC}"
+    echo "Please run this script from within a tmux session"
+    exit 1
+fi
+
+CURRENT_SESSION=$(tmux display-message -p "#{session_name}")
+CURRENT_WINDOW=$(tmux display-message -p "#{window_index}")
+CURRENT_PANE=$(tmux display-message -p "#{pane_index}")
+
+echo -e "${GREEN}📍 Current Location:${NC}"
+echo "   Session: $CURRENT_SESSION"
+echo "   Window: $CURRENT_WINDOW"
+echo "   Pane: $CURRENT_PANE"
+echo
+
+# Check if preset exists
+echo -e "${BLUE}🎯 Setting up preset: $PRESET_NAME${NC}"
+
+if ! python3 "$SCRIPT_DIR/permission_presets.py" "$PRESET_NAME" > /dev/null 2>&1; then
+    echo -e "${RED}❌ Error: Unknown preset '$PRESET_NAME'${NC}"
+    echo
+    echo -e "${YELLOW}Available presets:${NC}"
+    python3 "$SCRIPT_DIR/permission_presets.py"
+    exit 1
+fi
+
+# Generate session-specific configuration file
+CONFIG_FILE="$SCRIPT_DIR/auto_responder_config_${CURRENT_SESSION}.json"
+echo -e "${BLUE}📝 Generating session-specific configuration...${NC}"
+echo "   Config file: $CONFIG_FILE"
+
+python3 "$SCRIPT_DIR/permission_presets.py" "$PRESET_NAME" > "$CONFIG_FILE"
+
+if [ $? -eq 0 ]; then
+    echo -e "${GREEN}✅ Configuration saved to: $CONFIG_FILE${NC}"
+else
+    echo -e "${RED}❌ Error generating configuration${NC}"
+    exit 1
+fi
+
+# Show what will be enabled
+echo
+echo -e "${YELLOW}🎛️  Preset Configuration:${NC}"
+case "$PRESET_NAME" in
+    "safe_development")
+        echo "   ✅ File operations (safe for coding)"
+        echo "   ✅ General confirmations"
+        echo "   ✅ Continue operations"
+        echo "   ❌ Command execution (manual control)"
+        echo "   ❌ Git operations (manual control)"
+        echo "   ❌ Package management (manual control)"
+        echo "   🛡️  Risk Level: LOW"
+        ;;
+    "autonomous_agent")
+        echo "   ✅ File operations"
+        echo "   ✅ Command execution"
+        echo "   ✅ General confirmations"
+        echo "   ✅ Persistent choices (don't ask again)"
+        echo "   ✅ Continue operations"
+        echo "   ✅ Package management"
+        echo "   ❌ Git operations (manual for safety)"
+        echo "   ⚠️  Risk Level: MEDIUM"
+        ;;
+    "conservative")
+        echo "   ✅ General confirmations only"
+        echo "   ❌ Everything else disabled"
+        echo "   🔒 Risk Level: VERY LOW"
+        ;;
+    "pm_orchestrator")
+        echo "   ✅ File operations (documentation)"
+        echo "   ✅ General confirmations"
+        echo "   ✅ Continue operations"
+        echo "   ❌ Command execution (PMs don't code)"
+        echo "   ❌ Git operations (oversight only)"
+        echo "   ❌ Package management (developers handle)"
+        echo "   🛡️  Risk Level: LOW-MEDIUM"
+        ;;
+esac
+
+echo
+echo -e "${YELLOW}🛡️  Safety Features Always Active:${NC}"
+echo "   • Blocks dangerous operations (delete, rm -rf, etc.)"
+echo "   • Requires manual approval for production operations"
+echo "   • Complete audit trail of all responses"
+echo "   • Can be stopped anytime with Ctrl+C"
+
+# Auto-proceed without confirmation for automation
+echo
+echo -e "${GREEN}🚀 Proceeding with automatic setup...${NC}"
+
+# Create auto-responder window
+echo -e "${BLUE}🔧 Setting up auto-responder window...${NC}"
+
+RESPONDER_WINDOW="Auto-Responder-${PRESET_NAME}"
+
+# Check if auto-responder window already exists and kill it automatically
+if tmux list-windows -t "$CURRENT_SESSION" -F "#{window_name}" | grep -q "^$RESPONDER_WINDOW$"; then
+    echo -e "${YELLOW}⚠️  Auto-responder window already exists - killing and recreating${NC}"
+    tmux kill-window -t "$CURRENT_SESSION:$RESPONDER_WINDOW" 2>/dev/null || true
+    sleep 1
+fi
+
+# Create new auto-responder window
+tmux new-window -t "$CURRENT_SESSION" -n "$RESPONDER_WINDOW" -d
+
+# Start the auto-responder in the new window
+echo -e "${BLUE}🚀 Starting auto-responder...${NC}"
+
+# Check if integrated_auto_responder.py exists
+if [ ! -f "$SCRIPT_DIR/integrated_auto_responder.py" ]; then
+    echo -e "${RED}❌ Error: integrated_auto_responder.py not found${NC}"
+    echo "Expected location: $SCRIPT_DIR/integrated_auto_responder.py"
+    exit 1
+fi
+
+tmux send-keys -t "$CURRENT_SESSION:$RESPONDER_WINDOW" "cd '$SCRIPT_DIR'" Enter
+tmux send-keys -t "$CURRENT_SESSION:$RESPONDER_WINDOW" "python3 integrated_auto_responder.py start '$CURRENT_SESSION' '$PRESET_NAME'" Enter
+
+# Wait for startup and check multiple times
+echo -e "${BLUE}⏳ Waiting for auto-responder to start...${NC}"
+sleep 3
+
+# Check if it's running (try multiple patterns)
+RESPONDER_OUTPUT=$(tmux capture-pane -t "$CURRENT_SESSION:$RESPONDER_WINDOW" -p)
+
+if echo "$RESPONDER_OUTPUT" | grep -q -E "(Auto-responder started|🚀.*started|Monitoring.*session)"; then
+    echo -e "${GREEN}✅ Auto-responder successfully started!${NC}"
+elif echo "$RESPONDER_OUTPUT" | grep -q -E "(Error|❌|Traceback|Exception)"; then
+    echo -e "${RED}❌ Error detected in auto-responder:${NC}"
+    echo "$RESPONDER_OUTPUT"
+    echo -e "${YELLOW}💡 Try running manually: tmux select-window -t $CURRENT_SESSION:$RESPONDER_WINDOW${NC}"
+else
+    echo -e "${YELLOW}⚠️  Auto-responder status unclear. Check the window manually.${NC}"
+    echo -e "${BLUE}Output:${NC}"
+    echo "$RESPONDER_OUTPUT"
+fi
+
+echo
+echo -e "${GREEN}🎉 Setup Complete!${NC}"
+echo "=================================="
+echo -e "${GREEN}✅ Auto-responder is now monitoring session: $CURRENT_SESSION${NC}"
+echo -e "${GREEN}✅ Using preset: $PRESET_NAME${NC}"
+echo -e "${GREEN}✅ Configuration: $CONFIG_FILE${NC}"
+echo
+echo -e "${BLUE}📋 Management Commands:${NC}"
+echo "   View status:     tmux select-window -t $CURRENT_SESSION:$RESPONDER_WINDOW"
+echo "   Stop responder:  tmux kill-window -t $CURRENT_SESSION:$RESPONDER_WINDOW"
+echo "   View logs:       python3 integrated_auto_responder.py status"
+echo
+echo -e "${BLUE}🔧 Customization:${NC}"
+echo "   Edit config:     nano $CONFIG_FILE"
+echo "   Change preset:   ./enable_auto_responder.sh <preset_name>"
+echo "   Available presets: safe_development, autonomous_agent, conservative, pm_orchestrator"
+echo
+echo -e "${YELLOW}💡 Pro Tip for PMs:${NC}"
+echo "   Add this to your PM startup routine:"
+echo "   ${GREEN}./enable_auto_responder.sh pm_orchestrator${NC}"
+echo
+echo -e "${BLUE}🛡️  Remember: This is MUCH safer than --dangerously-skip-permissions${NC}"
+echo "   • Maintains Claude's permission system"
+echo "   • Granular control over what gets approved"
+echo "   • Safety controls prevent dangerous operations"
+echo "   • Complete audit trail"
+
+# Return to original window
+tmux select-window -t "$CURRENT_SESSION:$CURRENT_WINDOW"
+
+echo
+echo -e "${GREEN}Ready! Your Claude session is now semi-automated. 🚀${NC}"

--- a/integrated_auto_responder.py
+++ b/integrated_auto_responder.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env python3
+"""
+Integrated Claude Auto-Responder for Tmux Orchestrator
+
+This version can be enabled directly from the orchestrator configuration
+and provides safer, more controlled automation than --dangerously-skip-permissions.
+"""
+
+import subprocess
+import time
+import re
+import sys
+import json
+import os
+import threading
+from typing import List, Dict, Optional
+from datetime import datetime
+
+class IntegratedAutoResponder:
+    """
+    Integrated auto-responder that can be controlled by the orchestrator.
+    
+    Key differences from --dangerously-skip-permissions:
+    - Maintains Claude's permission system
+    - Only responds to specific confirmation prompts
+    - Logs all responses for audit trail
+    - Can be configured to skip dangerous operations
+    - Granular control over what gets auto-confirmed
+    """
+
+    def __init__(self, config_path: str = "auto_responder_config.json", preset: str = "pm_orchestrator"):
+        self.config_path = config_path
+        self.preset = preset
+        self.config = self.load_config()
+        self.running = False
+        self.response_log = []
+        self.script_dir = os.path.dirname(os.path.abspath(__file__))
+        
+    def load_config(self) -> Dict:
+        """Load configuration from JSON file or generate from preset."""
+        try:
+            # Try to load from file first
+            with open(self.config_path, 'r') as f:
+                all_configs = json.load(f)
+
+            # If file contains multiple presets, use the specified one
+            if self.preset in all_configs:
+                return all_configs[self.preset]
+            # If file contains single config, use it directly
+            elif "auto_responder" in all_configs:
+                return all_configs
+            else:
+                print(f"⚠️  Preset '{self.preset}' not found in config file")
+                return self.get_preset_config()
+
+        except FileNotFoundError:
+            print(f"⚠️  Config file {self.config_path} not found, using preset: {self.preset}")
+            return self.get_preset_config()
+        except json.JSONDecodeError as e:
+            print(f"❌ Error parsing config file: {e}")
+            return self.get_preset_config()
+
+    def get_preset_config(self) -> Dict:
+        """Get configuration for the specified preset."""
+        try:
+            from permission_presets import get_preset
+            return get_preset(self.preset)
+        except ImportError:
+            print(f"❌ Could not import permission_presets")
+            return self.get_default_config()
+        except ValueError as e:
+            print(f"❌ {e}")
+            return self.get_default_config()
+
+    def get_default_config(self) -> Dict:
+        """Return default configuration."""
+        return {
+            "auto_responder": {
+                "enabled": False,
+                "check_interval": 2.0,
+                "response_delay": 0.5,
+                "log_responses": True,
+                "patterns": {
+                    "confirmation_prompts": [
+                        r"1\.\s*yes\s*2\.\s*no",
+                        r"Confirm\?\s*\(yes/no\)",
+                        r"Continue\?\s*\(y/n\)",
+                        r"Proceed\?\s*\(yes/no\)"
+                    ],
+                    "skip_patterns": [
+                        "delete", "remove", "rm -rf", "DROP TABLE", "DELETE FROM"
+                    ]
+                },
+                "responses": {
+                    "default": "1",
+                    "yes_and_dont_ask": "2"
+                }
+            }
+        }
+
+    def is_enabled(self) -> bool:
+        """Check if auto-responder is enabled in config."""
+        return self.config.get("auto_responder", {}).get("enabled", False)
+
+    def enable(self):
+        """Enable auto-responder and save config."""
+        if "auto_responder" not in self.config:
+            self.config["auto_responder"] = {}
+        self.config["auto_responder"]["enabled"] = True
+        self.save_config()
+        print("✅ Auto-responder enabled")
+
+    def disable(self):
+        """Disable auto-responder and save config."""
+        if "auto_responder" not in self.config:
+            self.config["auto_responder"] = {}
+        self.config["auto_responder"]["enabled"] = False
+        self.save_config()
+        self.stop()
+        print("❌ Auto-responder disabled")
+
+    def save_config(self):
+        """Save current configuration to file."""
+        try:
+            with open(self.config_path, 'w') as f:
+                json.dump(self.config, f, indent=2)
+        except Exception as e:
+            print(f"❌ Error saving config: {e}")
+
+    def get_session_windows(self, session_name: str) -> List[int]:
+        """Get all windows in a tmux session."""
+        try:
+            cmd = ["tmux", "list-windows", "-t", session_name, "-F", "#{window_index}"]
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            return [int(w) for w in result.stdout.strip().split('\n') if w]
+        except subprocess.CalledProcessError:
+            return []
+
+    def capture_window_content(self, session_name: str, window_index: int, lines: int = 20) -> str:
+        """Capture content from a tmux window."""
+        try:
+            cmd = ["tmux", "capture-pane", "-t", f"{session_name}:{window_index}",
+                   "-p", "-S", f"-{lines}"]
+            result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            return result.stdout
+        except subprocess.CalledProcessError:
+            return ""
+
+    def is_dangerous_operation(self, content: str) -> bool:
+        """Check if the content contains dangerous operations that should be skipped."""
+        safety_controls = self.config.get("auto_responder", {}).get("safety_controls", {})
+
+        if not safety_controls.get("skip_dangerous_operations", True):
+            return False
+
+        dangerous_patterns = safety_controls.get("dangerous_patterns", [])
+        manual_approval_patterns = safety_controls.get("require_manual_approval", [])
+
+        # Check for dangerous operations
+        for pattern in dangerous_patterns:
+            if re.search(pattern, content, re.IGNORECASE):
+                return True
+
+        # Check for operations requiring manual approval
+        for pattern in manual_approval_patterns:
+            if re.search(pattern, content, re.IGNORECASE):
+                return True
+
+        return False
+
+    def check_for_confirmation_prompt(self, session_name: str, window_index: int) -> Optional[Dict]:
+        """Check if there's a confirmation prompt in the window with granular control."""
+        content = self.capture_window_content(session_name, window_index)
+        if not content:
+            return None
+
+        # Skip if dangerous operation detected
+        if self.is_dangerous_operation(content):
+            self.log_response(session_name, window_index, "SKIPPED", "Dangerous operation detected")
+            return None
+
+        # Check each granular control category
+        granular_controls = self.config.get("auto_responder", {}).get("granular_controls", {})
+
+        for category_name, category_config in granular_controls.items():
+            # Skip if this category is disabled
+            if not category_config.get("enabled", False):
+                continue
+
+            patterns = category_config.get("patterns", [])
+            response = category_config.get("response", "1")
+
+            for pattern in patterns:
+                if re.search(pattern, content, re.IGNORECASE | re.MULTILINE):
+                    return {
+                        "response": response,
+                        "category": category_name,
+                        "description": category_config.get("description", ""),
+                        "pattern_matched": pattern
+                    }
+
+        return None
+
+    def send_response(self, session_name: str, window_index: int, response: str) -> bool:
+        """Send response using send-claude-message.sh if available, fallback to direct tmux."""
+        send_script = os.path.join(self.script_dir, "send-claude-message.sh")
+        target = f"{session_name}:{window_index}"
+        
+        try:
+            if os.path.exists(send_script):
+                # Use send-claude-message.sh for consistency
+                cmd = [send_script, target, response]
+                subprocess.run(cmd, check=True, capture_output=True)
+                method = "send-claude-message.sh"
+            else:
+                # Fallback to direct tmux commands
+                subprocess.run(["tmux", "send-keys", "-t", target, response])
+                time.sleep(self.config.get("auto_responder", {}).get("response_delay", 0.5))
+                subprocess.run(["tmux", "send-keys", "-t", target, "Enter"])
+                method = "direct tmux"
+            
+            self.log_response(session_name, window_index, response, f"Success via {method}")
+            return True
+            
+        except subprocess.CalledProcessError as e:
+            self.log_response(session_name, window_index, response, f"Error: {e}")
+            return False
+
+    def log_response(self, session_name: str, window_index: int, response: str, status: str, category: str = "", description: str = ""):
+        """Log auto-responder actions with granular details."""
+        if not self.config.get("auto_responder", {}).get("log_responses", True):
+            return
+
+        log_entry = {
+            "timestamp": datetime.now().isoformat(),
+            "session": session_name,
+            "window": window_index,
+            "response": response,
+            "status": status,
+            "category": category,
+            "description": description
+        }
+
+        self.response_log.append(log_entry)
+        category_info = f" [{category}]" if category else ""
+        print(f"🤖 [{datetime.now().strftime('%H:%M:%S')}] {session_name}:{window_index}{category_info} → {response} ({status})")
+
+    def monitor_session(self, session_name: str):
+        """Monitor a single session for confirmation prompts."""
+        check_interval = self.config.get("auto_responder", {}).get("check_interval", 2.0)
+        
+        while self.running and self.is_enabled():
+            try:
+                windows = self.get_session_windows(session_name)
+                
+                for window_index in windows:
+                    if not self.running:
+                        break
+
+                    prompt_info = self.check_for_confirmation_prompt(session_name, window_index)
+                    if prompt_info:
+                        response = prompt_info["response"]
+                        category = prompt_info["category"]
+                        description = prompt_info["description"]
+
+                        success = self.send_response(session_name, window_index, response)
+                        if success:
+                            self.log_response(session_name, window_index, response, "Auto-approved", category, description)
+                
+                time.sleep(check_interval)
+                
+            except Exception as e:
+                print(f"❌ Error monitoring session {session_name}: {e}")
+                time.sleep(check_interval)
+
+    def start_for_session(self, session_name: str):
+        """Start monitoring a specific session in a background thread."""
+        if not self.is_enabled():
+            print("❌ Auto-responder is disabled in config")
+            return False
+            
+        self.running = True
+        thread = threading.Thread(target=self.monitor_session, args=(session_name,), daemon=True)
+        thread.start()
+        print(f"🚀 Auto-responder started for session: {session_name}")
+        return True
+
+    def stop(self):
+        """Stop the auto-responder."""
+        self.running = False
+        print("🛑 Auto-responder stopped")
+
+    def enable_category(self, category: str):
+        """Enable a specific approval category."""
+        if "auto_responder" not in self.config:
+            self.config["auto_responder"] = {}
+        if "granular_controls" not in self.config["auto_responder"]:
+            self.config["auto_responder"]["granular_controls"] = {}
+
+        if category in self.config["auto_responder"]["granular_controls"]:
+            self.config["auto_responder"]["granular_controls"][category]["enabled"] = True
+            self.save_config()
+            print(f"✅ Enabled auto-approval for: {category}")
+            return True
+        else:
+            print(f"❌ Unknown category: {category}")
+            return False
+
+    def disable_category(self, category: str):
+        """Disable a specific approval category."""
+        if "auto_responder" not in self.config:
+            self.config["auto_responder"] = {}
+        if "granular_controls" not in self.config["auto_responder"]:
+            self.config["auto_responder"]["granular_controls"] = {}
+
+        if category in self.config["auto_responder"]["granular_controls"]:
+            self.config["auto_responder"]["granular_controls"][category]["enabled"] = False
+            self.save_config()
+            print(f"❌ Disabled auto-approval for: {category}")
+            return True
+        else:
+            print(f"❌ Unknown category: {category}")
+            return False
+
+    def list_categories(self) -> Dict:
+        """List all available approval categories and their status."""
+        granular_controls = self.config.get("auto_responder", {}).get("granular_controls", {})
+        categories = {}
+
+        for category, config in granular_controls.items():
+            categories[category] = {
+                "enabled": config.get("enabled", False),
+                "description": config.get("description", ""),
+                "patterns_count": len(config.get("patterns", []))
+            }
+
+        return categories
+
+    def get_status(self) -> Dict:
+        """Get current status and recent logs."""
+        return {
+            "enabled": self.is_enabled(),
+            "running": self.running,
+            "recent_responses": self.response_log[-10:],  # Last 10 responses
+            "categories": self.list_categories(),
+            "config": self.config.get("auto_responder", {})
+        }
+
+def main():
+    """CLI interface for the integrated auto-responder."""
+    if len(sys.argv) < 2:
+        print("Integrated Claude Auto-Responder with Granular Controls")
+        print("Usage:")
+        print("  python3 integrated_auto_responder.py enable")
+        print("  python3 integrated_auto_responder.py disable")
+        print("  python3 integrated_auto_responder.py start <session_name> [preset]")
+        print("  python3 integrated_auto_responder.py status [preset]")
+        print("  python3 integrated_auto_responder.py categories [preset]")
+        print("  python3 integrated_auto_responder.py enable-category <category> [preset]")
+        print("  python3 integrated_auto_responder.py disable-category <category> [preset]")
+        print("")
+        print("Available categories:")
+        print("  file_operations      - File creation, editing, saving")
+        print("  command_execution    - Shell commands and script execution")
+        print("  general_confirmations - General yes/no confirmations")
+        print("  persistent_choices   - Yes and don't ask again options")
+        print("  continue_operations  - Continue with current operation")
+        print("  package_management   - Package installations and updates")
+        print("  git_operations       - Git commits, pushes, and repository operations")
+        sys.exit(1)
+
+    responder = IntegratedAutoResponder()
+    command = sys.argv[1]
+
+    if command == "enable":
+        responder.enable()
+    elif command == "disable":
+        responder.disable()
+    elif command == "start" and len(sys.argv) > 2:
+        session_name = sys.argv[2]
+        preset = sys.argv[3] if len(sys.argv) > 3 else "pm_orchestrator"
+
+        # Create responder with specific preset
+        responder = IntegratedAutoResponder(preset=preset)
+
+        if responder.start_for_session(session_name):
+            try:
+                while responder.running:
+                    time.sleep(1)
+            except KeyboardInterrupt:
+                responder.stop()
+    elif command == "status":
+        status = responder.get_status()
+        print(json.dumps(status, indent=2))
+    elif command == "categories":
+        categories = responder.list_categories()
+        print("📋 Auto-Approval Categories:")
+        for category, info in categories.items():
+            status = "✅ ENABLED" if info["enabled"] else "❌ DISABLED"
+            print(f"  {category}: {status}")
+            print(f"    Description: {info['description']}")
+            print(f"    Patterns: {info['patterns_count']}")
+            print()
+    elif command == "enable-category" and len(sys.argv) > 2:
+        category = sys.argv[2]
+        responder.enable_category(category)
+    elif command == "disable-category" and len(sys.argv) > 2:
+        category = sys.argv[2]
+        responder.disable_category(category)
+    else:
+        print("❌ Invalid command")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/permission_presets.py
+++ b/permission_presets.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""
+Permission Presets for Claude Auto-Responder
+
+Unified configuration system where each permission specifies which presets include it.
+No code duplication - much cleaner and easier to maintain.
+"""
+
+# 🎯 UNIFIED CONFIGURATION - Each permission lists which presets enable it
+
+# 🎛️ GRANULAR CONTROLS CONFIGURATION
+# Each control specifies which presets enable it
+GRANULAR_CONTROLS = {
+    "file_operations": {
+        "description": "File creation, editing, saving",
+        "patterns": [
+            "Apply these changes\\?",
+            "Save file\\?",
+            "Create file\\?",
+            "Overwrite file\\?",
+            "Write to file\\?"
+        ],
+        "response": "1",
+        "enabled_in": ["pm_orchestrator", "safe_development", "autonomous_agent"]
+    },
+    "command_execution": {
+        "description": "Shell commands and script execution",
+        "patterns": [
+            "Execute this command\\?",
+            "Run this script\\?",
+            "Execute in terminal\\?",
+            "Run command\\?"
+        ],
+        "response": "1",
+        "enabled_in": ["autonomous_agent"]
+    },
+    "general_confirmations": {
+        "description": "General yes/no confirmations",
+        "patterns": [
+            "1\\. yes\\s*2\\. no",
+            "Confirm\\?\\s*\\(yes/no\\)",
+            "Continue\\?\\s*\\(y/n\\)",
+            "Proceed\\?\\s*\\(yes/no\\)"
+        ],
+        "response": "1",
+        "enabled_in": ["pm_orchestrator", "safe_development", "conservative", "autonomous_agent"]
+    },
+    "persistent_choices": {
+        "description": "Yes and don't ask again options",
+        "patterns": [
+            "1\\. yes\\s*2\\. yes and don't ask again\\s*3\\. no"
+        ],
+        "response": "2",
+        "enabled_in": ["autonomous_agent"]
+    },
+    "continue_operations": {
+        "description": "Continue with current operation",
+        "patterns": [
+            "Do you want to continue\\?",
+            "Do you want to proceed\\?",
+            "Continue with this action\\?"
+        ],
+        "response": "1",
+        "enabled_in": ["pm_orchestrator", "safe_development", "autonomous_agent"]
+    },
+    "package_management": {
+        "description": "Package installations and updates",
+        "patterns": [
+            "Install package\\?",
+            "Update dependencies\\?",
+            "Add to package\\.json\\?",
+            "Install npm package\\?"
+        ],
+        "response": "1",
+        "enabled_in": ["autonomous_agent"]
+    },
+    "git_operations": {
+        "description": "Git commits, pushes, and repository operations",
+        "patterns": [
+            "Commit changes\\?",
+            "Push to repository\\?",
+            "Create branch\\?",
+            "Merge branch\\?"
+        ],
+        "response": "1",
+        "enabled_in": []  # Disabled in all presets for safety
+    }
+}
+
+# 🛡️ SAFETY CONTROLS CONFIGURATION
+SAFETY_CONTROLS = {
+    "skip_dangerous_operations": True,
+    "dangerous_patterns": [
+        "delete", "remove", "rm -rf", "DROP TABLE", "DELETE FROM",
+        "truncate", "format", "destroy", "purge"
+    ],
+    "require_manual_approval": [
+        "production", "prod", "live", "master", "main branch"
+    ]
+}
+
+# 📋 PRESET METADATA
+PRESET_INFO = {
+    "pm_orchestrator": {
+        "description": "PM Orchestrator Preset",
+        "perfect_for": "Project management, team coordination, oversight",
+        "risk_level": "LOW-MEDIUM ⚠️",
+        "check_interval": 2.0,
+        "response_delay": 0.5
+    },
+    "safe_development": {
+        "description": "Safe Development Preset",
+        "perfect_for": "Daily coding, file editing, basic development",
+        "risk_level": "LOW ✅",
+        "check_interval": 2.0,
+        "response_delay": 0.5
+    },
+    "conservative": {
+        "description": "Conservative Preset",
+        "perfect_for": "Learning, testing, high-security environments",
+        "risk_level": "VERY LOW 🔒",
+        "check_interval": 3.0,
+        "response_delay": 1.0
+    },
+    "autonomous_agent": {
+        "description": "Autonomous Agent Preset",
+        "perfect_for": "Overnight development, autonomous agents, CI/CD",
+        "risk_level": "MEDIUM ⚠️",
+        "check_interval": 1.5,
+        "response_delay": 0.3
+    }
+}
+
+def generate_preset_config(preset_name):
+    """Generate configuration for a specific preset."""
+    if preset_name not in PRESET_INFO:
+        available = ", ".join(PRESET_INFO.keys())
+        raise ValueError(f"Unknown preset '{preset_name}'. Available: {available}")
+
+    preset_info = PRESET_INFO[preset_name]
+
+    # Generate granular controls for this preset
+    granular_controls = {}
+    for control_name, control_config in GRANULAR_CONTROLS.items():
+        enabled = preset_name in control_config["enabled_in"]
+        granular_controls[control_name] = {
+            "enabled": enabled,
+            "description": control_config["description"],
+            "patterns": control_config["patterns"],
+            "response": control_config["response"]
+        }
+    return {
+        "auto_responder": {
+            "enabled": True,
+            "check_interval": preset_info["check_interval"],
+            "response_delay": preset_info["response_delay"],
+            "log_responses": True,
+            "granular_controls": granular_controls,
+            "safety_controls": SAFETY_CONTROLS
+        }
+    }
+
+# 🎯 LEGACY FUNCTIONS (for backward compatibility)
+def safe_development():
+    """Safe Development Preset - Perfect for: Daily coding, file editing, basic development - Risk Level: LOW ✅"""
+    return generate_preset_config("safe_development")
+
+def autonomous_agent():
+    """Autonomous Agent Preset - Perfect for: Overnight development, autonomous agents, CI/CD - Risk Level: MEDIUM ⚠️"""
+    return generate_preset_config("autonomous_agent")
+
+def conservative():
+    """Conservative Preset - Perfect for: Learning, testing, high-security environments - Risk Level: VERY LOW 🔒"""
+    return generate_preset_config("conservative")
+
+def pm_orchestrator():
+    """PM Orchestrator Preset - Perfect for: Project management, team coordination, oversight - Risk Level: LOW-MEDIUM ⚠️"""
+    return generate_preset_config("pm_orchestrator")
+
+# 🎯 PRESET REGISTRY
+PRESETS = {
+    "safe_development": safe_development,
+    "autonomous_agent": autonomous_agent,
+    "conservative": conservative,
+    "pm_orchestrator": pm_orchestrator
+}
+
+def get_preset(name):
+    """Get a preset configuration by name."""
+    if name in PRESETS:
+        return PRESETS[name]()
+    else:
+        return generate_preset_config(name)
+
+def list_presets():
+    """List all available presets with descriptions."""
+    print("🎯 Available Permission Presets:")
+    print("=" * 40)
+
+    for name, info in PRESET_INFO.items():
+        print(f"\n📋 {name}")
+        print(f"   {info['description']}")
+        print(f"   Perfect for: {info['perfect_for']}")
+        print(f"   Risk Level: {info['risk_level']}")
+
+        # Show what's enabled
+        enabled_controls = []
+        for control_name, control_config in GRANULAR_CONTROLS.items():
+            if name in control_config["enabled_in"]:
+                enabled_controls.append(control_name)
+
+        if enabled_controls:
+            print(f"   ✅ Enabled: {', '.join(enabled_controls)}")
+        else:
+            print(f"   ✅ Enabled: general_confirmations only")
+
+if __name__ == "__main__":
+    import sys
+    import json
+
+    if len(sys.argv) < 2:
+        list_presets()
+        print(f"\nUsage: python3 {sys.argv[0]} <preset_name>")
+        print("Example: python3 permission_presets.py safe_development")
+        sys.exit(1)
+
+    preset_name = sys.argv[1]
+    try:
+        config = get_preset(preset_name)
+        print(json.dumps(config, indent=2))
+    except ValueError as e:
+        print(f"❌ {e}")
+        sys.exit(1)
+
+

--- a/start_auto_responder.sh
+++ b/start_auto_responder.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Claude Auto-Responder Launcher
+# Starts the auto-responder in a dedicated tmux window
+#
+
+SESSION_NAME=${1:-"antko-corporate"}
+CHECK_INTERVAL=${2:-2.0}
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "🚀 Starting Claude Auto-Responder for session: $SESSION_NAME"
+
+# Create dedicated window for the watcher
+tmux new-window -t "$SESSION_NAME" -n "Auto-Responder" -d
+
+# Execute the watcher in that window
+tmux send-keys -t "$SESSION_NAME:Auto-Responder" "cd $SCRIPT_DIR" Enter
+tmux send-keys -t "$SESSION_NAME:Auto-Responder" "python3 claude_auto_responder.py $SESSION_NAME $CHECK_INTERVAL" Enter
+
+echo "✅ Auto-responder started in window 'Auto-Responder'"
+echo "🔍 Monitoring all windows in session '$SESSION_NAME'"
+echo "🛑 To stop: tmux kill-window -t $SESSION_NAME:Auto-Responder"

--- a/start_auto_responder.sh
+++ b/start_auto_responder.sh
@@ -4,9 +4,30 @@
 # Starts the auto-responder in a dedicated tmux window
 #
 
-SESSION_NAME=${1:-"antko-corporate"}
+# Check if session name is provided
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <session_name> [check_interval]"
+    echo "Example: $0 my-session 2.0"
+    echo ""
+    echo "Available tmux sessions:"
+    tmux list-sessions 2>/dev/null || echo "  No tmux sessions found"
+    exit 1
+fi
+
+SESSION_NAME="$1"
 CHECK_INTERVAL=${2:-2.0}
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Verify the session exists
+if ! tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+    echo "❌ Error: Session '$SESSION_NAME' does not exist"
+    echo ""
+    echo "Available tmux sessions:"
+    tmux list-sessions 2>/dev/null || echo "  No tmux sessions found"
+    echo ""
+    echo "To create a new session: tmux new-session -s $SESSION_NAME"
+    exit 1
+fi
 
 echo "🚀 Starting Claude Auto-Responder for session: $SESSION_NAME"
 


### PR DESCRIPTION
# 🎯 Granular Auto-Responder with Unified Preset System

## 📋 Overview

This PR introduces a granular auto-responder system that provides a **much safer alternative to `--dangerously-skip-permissions`** while maintaining Claude's security model and offering fine-grained control over automated responses.

## 🚀 Key Features

### **4 Predefined Presets**
- **`pm_orchestrator`** - PM-optimized (file ops, confirmations, no commands) - Risk: LOW-MEDIUM ⚠️
- **`safe_development`** - Developer-safe (files, confirmations, manual commands) - Risk: LOW ✅  
- **`conservative`** - Minimal automation (basic confirmations only) - Risk: VERY LOW 🔒
- **`autonomous_agent`** - Full automation (everything except git) - Risk: MEDIUM ⚠️

### **Unified Configuration System**
- Single source of truth in `permission_presets.py`
- No code duplication - each permission specifies which presets enable it
- Easy to add new presets or modify existing ones
- Backward compatible with legacy function calls

### **Multiple Auto-Responders**
- Each tmux session can run different presets simultaneously
- Unique window names per preset: `Auto-Responder-pm_orchestrator`
- Independent configurations without conflicts

## 🛡️ Safety Features

### **Always Active Safety Controls**
- Blocks dangerous operations: `delete`, `rm -rf`, `DROP TABLE`, etc.
- Requires manual approval for production operations
- Complete audit trail of all automated responses
- Can be stopped anytime (kill Auto-Responder window)

### **Granular Permission Categories**
- `file_operations` - File creation, editing, saving
- `command_execution` - Shell commands and script execution  
- `general_confirmations` - Basic yes/no confirmations
- `persistent_choices` - "Yes and don't ask again" options
- `continue_operations` - "Do you want to proceed?" prompts
- `package_management` - Package installations and updates
- `git_operations` - Git commits, pushes (disabled by default)

## 🎛️ Usage

### **New Claude Commands**
```bash
# Enable auto-responder with specific preset
/enable-auto pm
/enable-auto safe  
/enable-auto conservative
/enable-auto autonomous

# Disable auto-responder
/disable-auto

# Enable with preset
./enable_auto_responder.sh pm_orchestrator

# Multiple sessions can use different presets
./enable_auto_responder.sh conservative  # In engineer session
./enable_auto_responder.sh pm_orchestrator  # In PM session

# PM enables auto-responder for management tasks
/enable-auto pm
```
# Example:
PM creates engineer and sets up conservative auto-responder

"You are a project manager, create an engineer in window 2 and say him:
 '/enable-auto conservative' and after say him create denofresh default 
 project for now, schedule in 10 minutes to check engineer progress"


# 🆚 Benefits Over `--dangerously-skip-permissions`

| Feature     | Auto-Responder                          | `--dangerously-skip-permissions`           |
|-------------|------------------------------------------|---------------------------------------------|
| **Security**  | ✅ Maintains Claude's permission system   | ❌ Bypasses **ALL** safety checks            |
| **Control**   | ✅ Granular per-operation type            | ❌ All-or-nothing approach                   |
| **Safety**    | ✅ Blocks dangerous operations            | ❌ No safety controls                        |
| **Audit**     | ✅ Complete response trail                | ❌ No logging                                |
| **Flexibility**| ✅ Multiple presets available             | ❌ Single dangerous mode                     |
| **Reversible**| ✅ Can be stopped anytime                | ❌ Requires restart                          |

